### PR TITLE
Escape plain text

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,13 @@ function bfsOrder (node) {
   outqueue.shift()
   return outqueue
 }
+function escape(text) {
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/#/g, '\\#')
+    .replace(/_/g, '\\_')
+    .replace(/\*/g, '\\*');
+}
 
 /*
  * Contructs a Markdown string of replacement text for a given node
@@ -78,7 +85,7 @@ function getContent (node) {
     if (node.childNodes[i].nodeType === 1) {
       text += node.childNodes[i]._replacement
     } else if (node.childNodes[i].nodeType === 3) {
-      text += node.childNodes[i].data
+      text += escape(node.childNodes[i].data);
     } else continue
   }
   return text
@@ -213,7 +220,7 @@ toMarkdown = function (input, options) {
   }
   output = getContent(clone)
 
-	return output;
+  return output;
 }
 
 toMarkdown.isBlock = isBlock

--- a/lib/magnet-md-converters.js
+++ b/lib/magnet-md-converters.js
@@ -1,5 +1,6 @@
 'use strict'
 
+
 module.exports = [
   {
     filter : 'p',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "to-magnet-markdown",
   "description": "HTML-to-Markdown converter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Dom Christie",
   "browser": {
     "jsdom": false


### PR DESCRIPTION
Without escaping the plain text it will be interpreted as markdown.

@Magnetme/monolith - RFR but do not merge. It triggers related unescaping mayhem on Magnet.me