### PR TITLE
Fix escaping of full stop character

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,8 @@ function escape(text) {
     .replace(/\\/g, '\\\\')
     .replace(/#/g, '\\#')
     .replace(/_/g, '\\_')
-    .replace(/\*/g, '\\*');
+    .replace(/\*/g, '\\*')
+    .replace(/\./g, '\\.');
 }
 
 /*
@@ -200,9 +201,6 @@ toMarkdown = function (input, options) {
   if (typeof input !== 'string') {
     throw new TypeError(input + ' is not a string')
   }
-
-  // Escape potential ol triggers
-  input = input.replace(/(\d+)\. /g, '$1\\. ')
 
   var clone = htmlToDom(input).body
   var nodes = bfsOrder(clone)


### PR DESCRIPTION
This was a left-over of incorrect escaping: before [#3][1] `to-markdown`
would accidentally interpret plain text as markdown. The original author
likely already ran into issues with this, where numbers followed
by dots would be converted as `<ol>` items. The fix he put in place was
to escape all dots that where prefixed by a number (in the plain html
input). However, with the escaping mechanism put in place in [#3][1] the
escape character would be escaped again, causing a [leading slash to show
up in the output][2].

This commit removes the escape hack for dots, and adds dot-escaping to
the escape function.

[1]: https://github.com/Magnetme/to-magnet-markdown/pull/3
[2]: https://github.com/Magnetme/magnet.me/issues/8566

@Magnetme/monolith - FYI (don't think this needs much reviewing)